### PR TITLE
Make sure program output use utf-8 encoding

### DIFF
--- a/clawsker
+++ b/clawsker
@@ -11,6 +11,9 @@
 # See COPYING file for license details.
 # See AUTHORS file for a complete list of contributors.
 #
+
+binmode STDOUT, ":encoding(utf8)";
+
 use strict;
 use utf8;
 use Glib qw(TRUE FALSE);


### PR DESCRIPTION
Fixes formatting of output to terminal from --help and --version and similar options.
